### PR TITLE
fix: calculate remainder only once

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,10 @@ function parse(nhsNumber: unknown): number[] | null {
 }
 
 function calcCheckDigit(digits: number[]): number {
-	const total =
-		digits
-			.slice(0, 9)
-			.map((digit, ind) => digit * (11 - (ind + 1)))
-			.reduce((acc, cur) => acc + cur) % 11;
+	const total = digits
+		.slice(0, 9)
+		.map((digit, ind) => digit * (11 - (ind + 1)))
+		.reduce((acc, cur) => acc + cur);
 	const remainder = total % 11;
 	const checkDigit = remainder > 0 ? 11 - remainder : 0;
 	return checkDigit;


### PR DESCRIPTION
The calcCheckDigit function was calculating the remainder twice . This technically still work as taking the remainder of 11 twice will still produce the same result. Although this isn't the expected functionality.